### PR TITLE
Toast on permission revoked

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "cz.noharmdan.wirelessadb"
-        minSdk 23
+        minSdk 30
         targetSdk 31
         versionCode 1
         versionName "1.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,5 +52,5 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
     implementation 'androidx.activity:activity-compose:1.4.0'
-    implementation "com.google.accompanist:accompanist-systemuicontroller:0.24.6-alpha"
+    implementation "com.google.accompanist:accompanist-systemuicontroller:0.24.7-alpha"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,9 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="cz.noharmdan.wirelessadb">
 
-    <uses-permission android:name="android.permission.WRITE_SETTINGS"
-        tools:ignore="ProtectedPermissions" />
-    <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS"
+    <uses-permission
+        android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
 
     <application

--- a/app/src/main/java/cz/noharmdan/wirelessadb/service/WirelessTileService.kt
+++ b/app/src/main/java/cz/noharmdan/wirelessadb/service/WirelessTileService.kt
@@ -1,9 +1,12 @@
 package cz.noharmdan.wirelessadb.service
 
+import android.content.pm.PackageManager
 import android.os.Build
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
+import android.widget.Toast
 import androidx.annotation.RequiresApi
+import cz.noharmdan.wirelessadb.R
 import cz.noharmdan.wirelessadb.WADBApplication
 import cz.noharmdan.wirelessadb.repository.GlobalSettingsRepository
 import kotlinx.coroutines.*
@@ -33,9 +36,18 @@ class WirelessTileService : TileService() {
     override fun onClick() {
         super.onClick()
 
-        qsTile?.let {
-            GlobalSettingsRepository.isWirelessDebugEnabled = !GlobalSettingsRepository.isWirelessDebugEnabled
+        if (applicationContext.checkSelfPermission("android.permission.WRITE_SECURE_SETTINGS") != PackageManager.PERMISSION_GRANTED) {
+            Toast.makeText(
+                applicationContext,
+                R.string.write_secure_settings_permission_disabled_message,
+                Toast.LENGTH_LONG
+            )
+                .show()
+            return
         }
+
+        GlobalSettingsRepository.isWirelessDebugEnabled =
+            !GlobalSettingsRepository.isWirelessDebugEnabled
     }
 
     private fun updateTileState(isWirelessDebuggingOn: Boolean) {

--- a/app/src/main/java/cz/noharmdan/wirelessadb/ui/theme/Theme.kt
+++ b/app/src/main/java/cz/noharmdan/wirelessadb/ui/theme/Theme.kt
@@ -5,8 +5,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.Color
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 private val DarkColorPalette = darkColors(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Wireless ADB</string>
     <string name="title_wireless_debugging">Wireless Debugging</string>
+    <string name="write_secure_settings_permission_disabled_message">WRITE_SECURE_SETTINGS permission not enabled</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '7.1.2' apply false
-    id 'com.android.library' version '7.1.2' apply false
+    id 'com.android.application' version '7.1.3' apply false
+    id 'com.android.library' version '7.1.3' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
 }
 


### PR DESCRIPTION
**Preface**

Thanks for making this repository @NoHarmDan! This exact project was on my mind for a while. I was about to start writing my own implementation this morning when I did my due diligence and found your repository. And it works great!

I have a few suggestions in mind I hope you find useful in this PR and one additional I'll open later.

---

**Changes**

* When the user taps a quick toggle and does not have permission to change secure settings, a toast message will appear.
* Updates to dependencies
* Update `minSdk` to Android 11
    * Wireless debugging was first introduced in Android 11. Application is not useful for any prior Android OS.
* Other clean up 
